### PR TITLE
Improve header filtering

### DIFF
--- a/tests/RouterTest.php
+++ b/tests/RouterTest.php
@@ -692,6 +692,45 @@ class RouterTest extends \PHPUnit_Framework_TestCase {
         );
     }
 
+    public function testHeaderMatchCase() {
+        $r = new Router();
+        $route = array(
+            "type" => "exact",
+            "pattern" => "/foo/bar",
+            "action" => "FooBar",
+            "headers" => array(
+                "host" => "www.example.com"
+            )
+        );
+
+        $resp = $r->match_headers(
+            $route,
+            array(
+                "Host" => "www.example.com"
+            )
+        );
+        $this->assertEquals(
+            "www.example.com",
+            $resp["headers"]["host"]
+        );
+    }
+
+    public function testGetHeaders() {
+        $r = new Router();
+
+        $resp = $r->get_headers(
+            array(
+                "HTTP_HOST" => "www.example.com"
+            )
+        );
+        $this->assertEquals(
+            array(
+                "HOST" => "www.example.com"
+            ),
+            $resp
+        );
+    }
+
     public function testCheckMatchString() {
         $r = new Router();
         $result = $r->check_match("foo", "foo");


### PR DESCRIPTION
According to RFC 2616, header names are case-insensitive. This change conforms to that when filtering on headers.

When apache_request_headers is not available, use the HTTP_* values from the server array as the source of headers.