### PR TITLE
Update to require PHP 7.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 language: php
 dist: trusty
 php:
-  - '7.1'
-  - '7.2'
   - '7.3'
+  - '7.4'
 install: composer install
 script: vendor/bin/phpunit

--- a/README.md
+++ b/README.md
@@ -1,25 +1,30 @@
 # PageMill Router
 
-This library determines a route for a web request. It is built to be easy to use and fast.
+This library determines a route for a web request. It is built to be easy to
+use and fast.
 
 ## Basic Routing
 
-For the most basic of routing needs, an array can simply be passed to the Router class constructor. Each route array should consist of a `type`, `pattern`,  and either an `action` or array of sub-routes called `routes`.  While `action` has no meaning to the router itself, its purpose is for use after matching.
+For the most basic of routing needs, an array can simply be passed to the
+Router class constructor. Each route array should consist of a `type`,
+`pattern`,  and either an `action` or array of sub-routes called `routes`.
+While `action` has no meaning to the router itself, its purpose is for use
+after matching.
 
-```
+```php
 $r = new PageMill\Router\Router(
-    array(
-        array(
+    [
+        [
             "type" => "exact",
             "pattern" => "/foo",
             "action" => "Foo"
-        ),
-        array(
+        ],
+        [
             "type" => "exact",
             "pattern" => "/foo/bar",
             "action" => "FooBar"
-        ),
-    )
+        ],
+    ]
 );
 
 $route = $r->match("/foo");
@@ -29,7 +34,7 @@ $route = $r->match("/foo");
 
 You can also add routes using the `add` method.
 
-```
+```php
 $r = new PageMill\Router\Router();
 $r->add("exact", "/foo", "Foo");
 $r->add("exact", "/foo/bar/", "FooBar");
@@ -40,33 +45,40 @@ If performance is important, it is suggested to pass the routes into the constru
 
 ## Match Types
 
-There are three matching types supported.
+There are three matching types supported plus a default route.
 
-**exact** - The request path must match `pattern` exactly.
+**exact** -       The request path must match `pattern` exactly.
 
 **starts_with** - Matches when the request path begins with the exact value of `pattern`.
 
-**regex** - Uses a regular expression to match against the reqeust path.
+**regex** -       Uses a regular expression to match against the reqeust path.
+
+**default** -     A default route to use if no other route is matched. A default
+                  route does not require a `pattern`. There must only be one
+                  default route defined.
 
 ## Matching Tokens
 
-Optionally, a route can include an array of tokens that allow for using values from the request path to fill a named array in the return value of the `match` method. This is only valid for `starts_with` and `exact` match types.
+Optionally, a route can include an array of tokens that allow for using values
+from the request path to fill a named array in the return value of the `match`
+method. This is only valid for `starts_with` and `exact` match types.
 
-For `starts_with` matches, the tokens will be filled in based on values that appear in the request path between slashes (`/`) that are not part of the pattern.
+For `starts_with` matches, the tokens will be filled in based on values that
+appear in the request path between slashes (`/`) that are not part of the pattern.
 
-```
+```php
 $r = new PageMill\Router\Router(
-    array(
-        array(
+    [
+        [
             "type" => "starts_with",
             "pattern" => "/foo/",
             "action" => "Foo",
-            "tokens" = array(
+            "tokens" = [
                 "group",
                 "id"
-            )
-        )
-    )
+            ]
+        ]
+    ]
 );
 
 $route = $r->match("/foo/1/2/");
@@ -74,33 +86,34 @@ $route = $r->match("/foo/1/2/");
 
 The value of `$route` would be:
 
-```
+```php
 array(
     "type" => "starts_with",
     "pattern" => "/foo/",
     "action" => "Foo",
-    "tokens" = array(
+    "tokens" = [
         "group" => 1,
         "id" => 2
-    )
+    ]
 )
 ```
 
-For `regex` matches, the tokens will be filled based on back references used in the regular expression.
+For `regex` matches, the tokens will be filled based on back references used
+in the regular expression.
 
-```
+```php
 $r = new PageMill\Router\Router(
-    array(
-        array(
+    [
+        [
             "type" => "regex",
             "pattern" => "/foo/(\d+)/(\d+)/",
             "action" => "Foo",
-            "tokens" = array(
+            "tokens" = [
                 "group",
                 "id"
-            )
-        )
-    )
+            ]
+        ]
+    ]
 );
 
 $route = $r->match("/foo/1/2/");
@@ -108,292 +121,310 @@ $route = $r->match("/foo/1/2/");
 
 The value of `$route` would be:
 
-```
-array(
+```php
+[
     "type" => "regex",
     "pattern" => "/foo/",
     "action" => "Foo",
-    "tokens" = array(
+    "tokens" = [
         "group" => 1,
         "id" => 2
-    )
-)
+    ]
+]
 ```
 
 ## Matching Hostname, Request Method, Accept header, and Other HTTP Headers
 
-It is also possible to match on hostname, request method, Accept header, and other HTTP headers by adding these settings to the route array.
+It is also possible to match on hostname, request method, Accept header, and
+other HTTP headers by adding these settings to the route array.
 
 `host` - Matches the HTTP Host header.
 `method` - Matches the HTTP request method (GET, POST, etc.)
 `accept` - Validates the Accept header contains one of a list of mime types.
 `headers` - An array of headers and the patterns to match them.
 
-To match on hostname, add `host` to the route config. To only match `GET` requests, add `method`.
+To match on hostname, add `host` to the route config. To only match `GET`
+requests, add `method`.
 
-```
+```php
 $r = new PageMill\Router\Router(
-    array(
-        array(
+    [
+        [
             "type" => "regex",
             "pattern" => "/foo/(\d+)/(\d+)/",
             "action" => "Foo",
             "host" => "www.example.com",
             "method" => "GET"
-        )
-    )
+        ]
+    ]
 );
 $route = $r->match("/foo/1/2/");
 ```
 
 The value of `$route` would be:
 
-```
-array(
+```php
+[
     "type" => "starts_with",
     "pattern" => "/foo/",
     "action" => "Foo",
-    "tokens" = array(
+    "tokens" = [
         "group" => 1,
         "id" => 2
-    )
+    ]
     "host" => "www.example.com",
     "method" => "GET"
-)
+]
 ```
 
-By default, this is treated as an exact match. You can do more complex matching by providing an array with `type` and `pattern` set. This is true of `host`, `method` and the patterns in the `headers` array.
+By default, this is treated as an exact match. You can do more complex
+matching by providing an array with `type` and `pattern` set. This is true
+of `host`, `method` and the patterns in the `headers` array.
 
-```
+```php
 $r = new PageMill\Router\Router(
-    array(
-        array(
+    [
+        [
             "type" => "regex",
             "pattern" => "/foo/(\d+)/(\d+)/",
             "action" => "Foo",
-            "host" => array(
+            "host" => [
                 "type" => "regex",
                 "pattern" => '/\.example\.com$/'
-            ),
+            ],
             "method" => "GET"
-        )
-    )
+        ]
+    ]
 );
 $route = $r->match("/foo/1/2/");
 ```
 
-The matched values of these settings will be returned in the matched route array. The value of `$route` would be:
+The matched values of these settings will be returned in the matched route
+array. The value of `$route` would be:
 
-```
-array(
+```php
+[
     "type" => "starts_with",
     "pattern" => "/foo/",
     "action" => "Foo",
-    "tokens" = array(
+    "tokens" = [
         "group" => 1,
         "id" => 2
-    )
+    ]
     "host" => "www.example.com",
     "method" => "GET"
-)
+]
 ```
 
-To validate the Accept header against a list of mime types, this route config could be used. For this example, assume the Accept header from the client contains `text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8`.
+To validate the Accept header against a list of mime types, this route config
+could be used. For this example, assume the Accept header from the client contains `text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8`.
 
-NOTE: Unlike other options, the `accept` option only accepts a single string mime type or an array of mime types.
+NOTE: Unlike other options, the `accept` option only accepts a single string
+mime type or an array of mime types.
 
-```
+```php
 $r = new PageMill\Router\Router(
-    array(
-        array(
+    [
+        [
             "type" => "regex",
             "pattern" => "/foo/(\d+)/(\d+)/",
             "action" => "Foo",
-            "accept" => array(
+            "accept" => [
                 "text/html"
-            )
-        )
-    )
+            ]
+        ]
+    ]
 );
 $route = $r->match("/foo/1/2/");
 ```
 
 The value of `$route` would be:
 
-```
-array(
+```php
+[
     "type" => "starts_with",
     "pattern" => "/foo/",
     "action" => "Foo",
-    "tokens" = array(
+    "tokens" = [
         "group" => 1,
         "id" => 2
-    )
+    ]
     "accept" => "text/html"
-)
+]
 ```
 
-Router will honor the clients quality scores from the Accept header. For an explination of the quality score used in HTTP client Accept headers, see https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html. If the quality scores for the matching mime types is equal, the order they are defined in the configuration will be honored.
+Router will honor the clients quality scores from the Accept header. For an
+explination of the quality score used in HTTP client Accept headers, see
+https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html. If the quality scores
+for the matching mime types is equal, the order they are defined in the
+configuration will be honored.
 
-```
+```php
 $r = new PageMill\Router\Router(
-    array(
-        array(
+    [
+        [
             "type" => "regex",
             "pattern" => "/foo/(\d+)/(\d+)/",
             "action" => "Foo",
-            "accept" => array(
+            "accept" => [
                 "application/json"
                 "text/html"
-            )
-        )
-    )
+            ]
+        ]
+    ]
 );
 $route = $r->match("/foo/1/2/");
 ```
 
-Because the quality score for text/html is not defined in the Accept header, it is assumed to be 1. The value of `$route` would be:
+Because the quality score for text/html is not defined in the Accept header,
+it is assumed to be 1. The value of `$route` would be:
 
-```
-array(
+```php
+[
     "type" => "starts_with",
     "pattern" => "/foo/",
     "action" => "Foo",
-    "tokens" = array(
+    "tokens" = [
         "group" => 1,
         "id" => 2
-    )
+    ]
     "accept" => "text/html"
-)
+]
 ```
 
 To match an arbitrary HTTP header, add `headers` to the route config.
 
 This example will ensure that the `Authorization` header contains `12345678`.
 
-```
+```php
 $r = new PageMill\Router\Router(
-    array(
-        array(
+    [
+        [
             "type" => "regex",
             "pattern" => "/foo/(\d+)/(\d+)/",
             "action" => "Foo",
-            "headers" => array(
-                "Authorization" => array(
+            "headers" => [
+                "Authorization" => [
                     "type" => "exact",
                     "pattern" => '12345678'
-                )
-            )
-        )
-    )
+                ]
+            ]
+        ]
+    ]
 );
 $route = $r->match("/foo/1/2/");
 ```
 
 The value of `$route` would be:
 
-```
-array(
+```php
+[
     "type" => "starts_with",
     "pattern" => "/foo/",
     "action" => "Foo",
-    "tokens" = array(
+    "tokens" = [
         "group" => 1,
         "id" => 2
-    )
-    "headers" => array(
+    ]
+    "headers" => [
         "Authorization" => "12345678"
-    )
-)
+    ]
+]
 ```
 
 ## Default Route
 
-```
+```php
 $r = new PageMill\Router\Router(
-    array(
-        array(
+    [
+        [
             "type" => "exact",
             "pattern" => "/foo/",
             "action" => "Foo",
-        ),
-        array(
+        ],
+        [
             "type" => "default",
             "action" => "Default",
-        )
-    )
+        ]
+    ]
 );
 $route = $r->match("/foo/1/2/");
 ```
 
 The value of `$route` would be:
 
-```
-array(
+```php
+[
     "type" => "default",
     "action" => "Default",
-)
+]
 ```
 
-Note: No tokens will be returned and no pattern matching is performed on the path for the default route.
+Note: No tokens will be returned and no pattern matching is performed on the
+path for the default route.
 
-Only one default route is allowed. An `InvalidRoute` exception will be thrown if more than one route is defined.
-
-## Saving the Route List
-
-If you would like to save the route list for reuse, you can call the `get_routes()` method.
-
-```
-$r = new PageMill\Router\Router(
-    array(
-        array(
-            "type" => "exact",
-            "pattern" => "/foo/",
-            "action" => "Foo",
-        ),
-        array(
-            "type" => "default",
-            "action" => "Default",
-        )
-    )
-);
-$routes = $r->get_routes();
-```
+Only one default route is allowed. An `InvalidRoute` exception will be thrown
+if more than one default route is defined.
 
 ## Adding Sub Routes (aka Route Maps)
 
-If you have several routes that all have the same prefix or match the same pattern, it can be beneficial to group those routes as sub-routes under a more general route. For example, if we have multiple routes that fall under the `/foo` path, we could configure our routes like this:
+If you have several routes that all have the same prefix or match the same
+pattern, it can be beneficial to group those routes as sub-routes under a
+more general route. For example, if we have multiple routes that fall under
+the `/foo` path, we could configure our routes like this:
 
-```
+```php
 $r = new PageMill\Router\Router(
-    array(
-        array(
+    [
+        [
             "type" => "starts_with",
             "pattern" => "/foo",
-            "routes" => array(
-                array(
+            "routes" => [
+                [
                     "type" => "exact",
                     "pattern" => "/foo/bar",
                     "action" => "FooBar"
-                ),
-                array(
+                ],
+                [
                     "type" => "exact",
                     "pattern" => "/foo/baz",
                     "action" => "FooBaz"
-                ),
-            )
-        )
-    )
+                ],
+            ]
+        ]
+    ]
 );
 $route = $r->match("/foo/bar");
 ```
 
 The value of `$route` would be:
 
-```
-array(
+```php
+[
     "type" => "exact",
     "pattern" => "/foo/bar",
     "action" => "FooBar"
-)
+]
+```
+
+## Saving the Route List
+
+If you would like to save the route list for reuse, you can call the
+`getRoutes()` method.
+
+```php
+$r = new PageMill\Router\Router(
+    [
+        [
+            "type" => "exact",
+            "pattern" => "/foo/",
+            "action" => "Foo",
+        ],
+        [
+            "type" => "default",
+            "action" => "Default",
+        ]
+    ]
+);
+$routes = $r->get_routes();
 ```

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "pagemill/router",
     "type": "library",
     "description": "A PHP request router",
-    "homepage": "https://github.com/dealnews/PageMill.Router",
+    "homepage": "https://github.com/dealnews/pagemill-router",
     "license": "BSD-3-Clause",
     "authors": [
         {
@@ -13,10 +13,10 @@
         }
     ],
     "require-dev": {
-        "phpunit/phpunit": "6.3.*"
+        "phpunit/phpunit": "^9.0"
     },
     "require": {
-        "php": ">=7.0",
+        "php": "~7.3.0",
         "pagemill/pattern": "^1.0",
         "pagemill/accept": "^1.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -17,8 +17,8 @@
     },
     "require": {
         "php": "~7.3",
-        "pagemill/pattern": "^1.0",
-        "pagemill/accept": "^1.0"
+        "pagemill/pattern": "~2.0",
+        "pagemill/accept": "~2.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "phpunit/phpunit": "^9.0"
     },
     "require": {
-        "php": "~7.3.0",
+        "php": "~7.3",
         "pagemill/pattern": "^1.0",
         "pagemill/accept": "^1.0"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b956cc919d564d45f3fcd3b4dad4c5c7",
+    "content-hash": "646a8ff180df2af2b15286101499d390",
     "packages": [
         {
             "name": "pagemill/accept",
@@ -1671,7 +1671,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "~7.3.0"
+        "php": "~7.3"
     },
     "platform-dev": []
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,27 +4,27 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "646a8ff180df2af2b15286101499d390",
+    "content-hash": "35de54cb75c064a755d0ce8ffe258dbd",
     "packages": [
         {
             "name": "pagemill/accept",
-            "version": "v1.0",
+            "version": "v2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/dealnews/pagemill-accept.git",
-                "reference": "c40ee4b1665075fa87977224b034f7c01ca67971"
+                "reference": "1de3b4fcf9c8d71bd71c37a6d2ce97ae52d37a23"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/dealnews/pagemill-accept/zipball/c40ee4b1665075fa87977224b034f7c01ca67971",
-                "reference": "c40ee4b1665075fa87977224b034f7c01ca67971",
+                "url": "https://api.github.com/repos/dealnews/pagemill-accept/zipball/1de3b4fcf9c8d71bd71c37a6d2ce97ae52d37a23",
+                "reference": "1de3b4fcf9c8d71bd71c37a6d2ce97ae52d37a23",
                 "shasum": ""
             },
             "require": {
-                "pagemill/pattern": "^1.0"
+                "php": "~7.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^7.5"
+                "phpunit/phpunit": "^9.0"
             },
             "type": "library",
             "autoload": {
@@ -43,24 +43,27 @@
                 }
             ],
             "description": "Parses the HTTP Accept header and determes the preferred content type",
-            "time": "2019-07-26T01:07:22+00:00"
+            "time": "2020-03-22T10:36:39+00:00"
         },
         {
             "name": "pagemill/pattern",
-            "version": "v1.0",
+            "version": "v2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/dealnews/pagemill-pattern.git",
-                "reference": "55ca3814608927987250698a209d6b0a24f9f8ff"
+                "reference": "d8833aa1898d3bec9f275c60d110e72cf1b935fd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/dealnews/pagemill-pattern/zipball/55ca3814608927987250698a209d6b0a24f9f8ff",
-                "reference": "55ca3814608927987250698a209d6b0a24f9f8ff",
+                "url": "https://api.github.com/repos/dealnews/pagemill-pattern/zipball/d8833aa1898d3bec9f275c60d110e72cf1b935fd",
+                "reference": "d8833aa1898d3bec9f275c60d110e72cf1b935fd",
                 "shasum": ""
             },
+            "require": {
+                "php": "~7.3"
+            },
             "require-dev": {
-                "phpunit/phpunit": "^7.5"
+                "phpunit/phpunit": "^9.0"
             },
             "type": "library",
             "autoload": {
@@ -79,7 +82,7 @@
                 }
             ],
             "description": "Common pattern matching used in PageMill",
-            "time": "2019-07-26T00:29:08+00:00"
+            "time": "2020-03-22T10:11:23+00:00"
         }
     ],
     "packages-dev": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e0981382d0261b1a0a3184357ebe747b",
+    "content-hash": "b956cc919d564d45f3fcd3b4dad4c5c7",
     "packages": [
         {
             "name": "pagemill/accept",
@@ -85,16 +85,16 @@
     "packages-dev": [
         {
             "name": "doctrine/instantiator",
-            "version": "1.2.0",
+            "version": "1.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/instantiator.git",
-                "reference": "a2c590166b2133a4633738648b6b064edae0814a"
+                "reference": "ae466f726242e637cebdd526a7d991b9433bacf1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/a2c590166b2133a4633738648b6b064edae0814a",
-                "reference": "a2c590166b2133a4633738648b6b064edae0814a",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/ae466f726242e637cebdd526a7d991b9433bacf1",
+                "reference": "ae466f726242e637cebdd526a7d991b9433bacf1",
                 "shasum": ""
             },
             "require": {
@@ -137,20 +137,20 @@
                 "constructor",
                 "instantiate"
             ],
-            "time": "2019-03-17T17:37:11+00:00"
+            "time": "2019-10-21T16:45:58+00:00"
         },
         {
             "name": "myclabs/deep-copy",
-            "version": "1.9.1",
+            "version": "1.9.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "e6828efaba2c9b79f4499dae1d66ef8bfa7b2b72"
+                "reference": "b2c28789e80a97badd14145fda39b545d83ca3ef"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/e6828efaba2c9b79f4499dae1d66ef8bfa7b2b72",
-                "reference": "e6828efaba2c9b79f4499dae1d66ef8bfa7b2b72",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/b2c28789e80a97badd14145fda39b545d83ca3ef",
+                "reference": "b2c28789e80a97badd14145fda39b545d83ca3ef",
                 "shasum": ""
             },
             "require": {
@@ -185,26 +185,26 @@
                 "object",
                 "object graph"
             ],
-            "time": "2019-04-07T13:18:21+00:00"
+            "time": "2020-01-17T21:11:47+00:00"
         },
         {
             "name": "phar-io/manifest",
-            "version": "1.0.1",
+            "version": "1.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phar-io/manifest.git",
-                "reference": "2df402786ab5368a0169091f61a7c1e0eb6852d0"
+                "reference": "7761fcacf03b4d4f16e7ccb606d4879ca431fcf4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phar-io/manifest/zipball/2df402786ab5368a0169091f61a7c1e0eb6852d0",
-                "reference": "2df402786ab5368a0169091f61a7c1e0eb6852d0",
+                "url": "https://api.github.com/repos/phar-io/manifest/zipball/7761fcacf03b4d4f16e7ccb606d4879ca431fcf4",
+                "reference": "7761fcacf03b4d4f16e7ccb606d4879ca431fcf4",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-phar": "*",
-                "phar-io/version": "^1.0.1",
+                "phar-io/version": "^2.0",
                 "php": "^5.6 || ^7.0"
             },
             "type": "library",
@@ -240,20 +240,20 @@
                 }
             ],
             "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
-            "time": "2017-03-05T18:14:27+00:00"
+            "time": "2018-07-08T19:23:20+00:00"
         },
         {
             "name": "phar-io/version",
-            "version": "1.0.1",
+            "version": "2.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phar-io/version.git",
-                "reference": "a70c0ced4be299a63d32fa96d9281d03e94041df"
+                "reference": "45a2ec53a73c70ce41d55cedef9063630abaf1b6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phar-io/version/zipball/a70c0ced4be299a63d32fa96d9281d03e94041df",
-                "reference": "a70c0ced4be299a63d32fa96d9281d03e94041df",
+                "url": "https://api.github.com/repos/phar-io/version/zipball/45a2ec53a73c70ce41d55cedef9063630abaf1b6",
+                "reference": "45a2ec53a73c70ce41d55cedef9063630abaf1b6",
                 "shasum": ""
             },
             "require": {
@@ -287,39 +287,37 @@
                 }
             ],
             "description": "Library for handling version information and constraints",
-            "time": "2017-03-05T17:38:23+00:00"
+            "time": "2018-07-08T19:19:57+00:00"
         },
         {
             "name": "phpdocumentor/reflection-common",
-            "version": "1.0.1",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/ReflectionCommon.git",
-                "reference": "21bdeb5f65d7ebf9f43b1b25d404f87deab5bfb6"
+                "reference": "63a995caa1ca9e5590304cd845c15ad6d482a62a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionCommon/zipball/21bdeb5f65d7ebf9f43b1b25d404f87deab5bfb6",
-                "reference": "21bdeb5f65d7ebf9f43b1b25d404f87deab5bfb6",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionCommon/zipball/63a995caa1ca9e5590304cd845c15ad6d482a62a",
+                "reference": "63a995caa1ca9e5590304cd845c15ad6d482a62a",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.5"
+                "php": ">=7.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.6"
+                "phpunit/phpunit": "~6"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "2.x-dev"
                 }
             },
             "autoload": {
                 "psr-4": {
-                    "phpDocumentor\\Reflection\\": [
-                        "src"
-                    ]
+                    "phpDocumentor\\Reflection\\": "src/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -341,44 +339,42 @@
                 "reflection",
                 "static analysis"
             ],
-            "time": "2017-09-11T18:02:19+00:00"
+            "time": "2018-08-07T13:53:10+00:00"
         },
         {
             "name": "phpdocumentor/reflection-docblock",
-            "version": "4.3.1",
+            "version": "5.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-                "reference": "bdd9f737ebc2a01c06ea7ff4308ec6697db9b53c"
+                "reference": "cd72d394ca794d3466a3b2fc09d5a6c1dc86b47e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/bdd9f737ebc2a01c06ea7ff4308ec6697db9b53c",
-                "reference": "bdd9f737ebc2a01c06ea7ff4308ec6697db9b53c",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/cd72d394ca794d3466a3b2fc09d5a6c1dc86b47e",
+                "reference": "cd72d394ca794d3466a3b2fc09d5a6c1dc86b47e",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.0",
-                "phpdocumentor/reflection-common": "^1.0.0",
-                "phpdocumentor/type-resolver": "^0.4.0",
-                "webmozart/assert": "^1.0"
+                "ext-filter": "^7.1",
+                "php": "^7.2",
+                "phpdocumentor/reflection-common": "^2.0",
+                "phpdocumentor/type-resolver": "^1.0",
+                "webmozart/assert": "^1"
             },
             "require-dev": {
-                "doctrine/instantiator": "~1.0.5",
-                "mockery/mockery": "^1.0",
-                "phpunit/phpunit": "^6.4"
+                "doctrine/instantiator": "^1",
+                "mockery/mockery": "^1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.x-dev"
+                    "dev-master": "5.x-dev"
                 }
             },
             "autoload": {
                 "psr-4": {
-                    "phpDocumentor\\Reflection\\": [
-                        "src/"
-                    ]
+                    "phpDocumentor\\Reflection\\": "src"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -389,44 +385,46 @@
                 {
                     "name": "Mike van Riel",
                     "email": "me@mikevanriel.com"
+                },
+                {
+                    "name": "Jaap van Otterdijk",
+                    "email": "account@ijaap.nl"
                 }
             ],
             "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
-            "time": "2019-04-30T17:48:53+00:00"
+            "time": "2020-02-22T12:28:44+00:00"
         },
         {
             "name": "phpdocumentor/type-resolver",
-            "version": "0.4.0",
+            "version": "1.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/TypeResolver.git",
-                "reference": "9c977708995954784726e25d0cd1dddf4e65b0f7"
+                "reference": "7462d5f123dfc080dfdf26897032a6513644fc95"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/9c977708995954784726e25d0cd1dddf4e65b0f7",
-                "reference": "9c977708995954784726e25d0cd1dddf4e65b0f7",
+                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/7462d5f123dfc080dfdf26897032a6513644fc95",
+                "reference": "7462d5f123dfc080dfdf26897032a6513644fc95",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.5 || ^7.0",
-                "phpdocumentor/reflection-common": "^1.0"
+                "php": "^7.2",
+                "phpdocumentor/reflection-common": "^2.0"
             },
             "require-dev": {
-                "mockery/mockery": "^0.9.4",
-                "phpunit/phpunit": "^5.2||^4.8.24"
+                "ext-tokenizer": "^7.2",
+                "mockery/mockery": "~1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "1.x-dev"
                 }
             },
             "autoload": {
                 "psr-4": {
-                    "phpDocumentor\\Reflection\\": [
-                        "src/"
-                    ]
+                    "phpDocumentor\\Reflection\\": "src"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -439,37 +437,38 @@
                     "email": "me@mikevanriel.com"
                 }
             ],
-            "time": "2017-07-14T14:27:02+00:00"
+            "description": "A PSR-5 based resolver of Class names, Types and Structural Element Names",
+            "time": "2020-02-18T18:59:58+00:00"
         },
         {
             "name": "phpspec/prophecy",
-            "version": "1.8.1",
+            "version": "v1.10.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "1927e75f4ed19131ec9bcc3b002e07fb1173ee76"
+                "reference": "451c3cd1418cf640de218914901e51b064abb093"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/1927e75f4ed19131ec9bcc3b002e07fb1173ee76",
-                "reference": "1927e75f4ed19131ec9bcc3b002e07fb1173ee76",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/451c3cd1418cf640de218914901e51b064abb093",
+                "reference": "451c3cd1418cf640de218914901e51b064abb093",
                 "shasum": ""
             },
             "require": {
                 "doctrine/instantiator": "^1.0.2",
                 "php": "^5.3|^7.0",
-                "phpdocumentor/reflection-docblock": "^2.0|^3.0.2|^4.0",
-                "sebastian/comparator": "^1.1|^2.0|^3.0",
-                "sebastian/recursion-context": "^1.0|^2.0|^3.0"
+                "phpdocumentor/reflection-docblock": "^2.0|^3.0.2|^4.0|^5.0",
+                "sebastian/comparator": "^1.2.3|^2.0|^3.0|^4.0",
+                "sebastian/recursion-context": "^1.0|^2.0|^3.0|^4.0"
             },
             "require-dev": {
-                "phpspec/phpspec": "^2.5|^3.2",
+                "phpspec/phpspec": "^2.5 || ^3.2",
                 "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.5 || ^7.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.8.x-dev"
+                    "dev-master": "1.10.x-dev"
                 }
             },
             "autoload": {
@@ -502,44 +501,45 @@
                 "spy",
                 "stub"
             ],
-            "time": "2019-06-13T12:50:23+00:00"
+            "time": "2020-03-05T15:02:03+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "5.3.2",
+            "version": "8.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "c89677919c5dd6d3b3852f230a663118762218ac"
+                "reference": "31e94ccc084025d6abee0585df533eb3a792b96a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/c89677919c5dd6d3b3852f230a663118762218ac",
-                "reference": "c89677919c5dd6d3b3852f230a663118762218ac",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/31e94ccc084025d6abee0585df533eb3a792b96a",
+                "reference": "31e94ccc084025d6abee0585df533eb3a792b96a",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-xmlwriter": "*",
-                "php": "^7.0",
-                "phpunit/php-file-iterator": "^1.4.2",
-                "phpunit/php-text-template": "^1.2.1",
-                "phpunit/php-token-stream": "^2.0.1",
-                "sebastian/code-unit-reverse-lookup": "^1.0.1",
-                "sebastian/environment": "^3.0",
-                "sebastian/version": "^2.0.1",
-                "theseer/tokenizer": "^1.1"
+                "php": "^7.3",
+                "phpunit/php-file-iterator": "^3.0",
+                "phpunit/php-text-template": "^2.0",
+                "phpunit/php-token-stream": "^4.0",
+                "sebastian/code-unit-reverse-lookup": "^2.0",
+                "sebastian/environment": "^5.0",
+                "sebastian/version": "^3.0",
+                "theseer/tokenizer": "^1.1.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.0"
+                "phpunit/phpunit": "^9.0"
             },
             "suggest": {
-                "ext-xdebug": "^2.5.5"
+                "ext-pcov": "*",
+                "ext-xdebug": "*"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "5.3.x-dev"
+                    "dev-master": "8.0-dev"
                 }
             },
             "autoload": {
@@ -554,8 +554,8 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "role": "lead",
-                    "email": "sebastian@phpunit.de"
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
                 }
             ],
             "description": "Library that provides collection, processing, and rendering functionality for PHP code coverage information.",
@@ -565,29 +565,32 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2018-04-06T15:36:58+00:00"
+            "time": "2020-02-19T13:41:19+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
-            "version": "1.4.5",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "730b01bc3e867237eaac355e06a36b85dd93a8b4"
+                "reference": "354d4a5faa7449a377a18b94a2026ca3415e3d7a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/730b01bc3e867237eaac355e06a36b85dd93a8b4",
-                "reference": "730b01bc3e867237eaac355e06a36b85dd93a8b4",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/354d4a5faa7449a377a18b94a2026ca3415e3d7a",
+                "reference": "354d4a5faa7449a377a18b94a2026ca3415e3d7a",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": "^7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.4.x-dev"
+                    "dev-master": "3.0-dev"
                 }
             },
             "autoload": {
@@ -602,7 +605,7 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "email": "sb@sebastian-bergmann.de",
+                    "email": "sebastian@phpunit.de",
                     "role": "lead"
                 }
             ],
@@ -612,26 +615,84 @@
                 "filesystem",
                 "iterator"
             ],
-            "time": "2017-11-27T13:52:08+00:00"
+            "time": "2020-02-07T06:05:22+00:00"
         },
         {
-            "name": "phpunit/php-text-template",
-            "version": "1.2.1",
+            "name": "phpunit/php-invoker",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sebastianbergmann/php-text-template.git",
-                "reference": "31f8b717e51d9a2afca6c9f046f5d69fc27c8686"
+                "url": "https://github.com/sebastianbergmann/php-invoker.git",
+                "reference": "7579d5a1ba7f3ac11c80004d205877911315ae7a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/31f8b717e51d9a2afca6c9f046f5d69fc27c8686",
-                "reference": "31f8b717e51d9a2afca6c9f046f5d69fc27c8686",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/7579d5a1ba7f3ac11c80004d205877911315ae7a",
+                "reference": "7579d5a1ba7f3ac11c80004d205877911315ae7a",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": "^7.3"
+            },
+            "require-dev": {
+                "ext-pcntl": "*",
+                "phpunit/phpunit": "^9.0"
+            },
+            "suggest": {
+                "ext-pcntl": "*"
             },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Invoke callables with a timeout",
+            "homepage": "https://github.com/sebastianbergmann/php-invoker/",
+            "keywords": [
+                "process"
+            ],
+            "time": "2020-02-07T06:06:11+00:00"
+        },
+        {
+            "name": "phpunit/php-text-template",
+            "version": "2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-text-template.git",
+                "reference": "526dc996cc0ebdfa428cd2dfccd79b7b53fee346"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/526dc996cc0ebdfa428cd2dfccd79b7b53fee346",
+                "reference": "526dc996cc0ebdfa428cd2dfccd79b7b53fee346",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
             "autoload": {
                 "classmap": [
                     "src/"
@@ -653,32 +714,32 @@
             "keywords": [
                 "template"
             ],
-            "time": "2015-06-21T13:50:34+00:00"
+            "time": "2020-02-01T07:43:44+00:00"
         },
         {
             "name": "phpunit/php-timer",
-            "version": "1.0.9",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-timer.git",
-                "reference": "3dcf38ca72b158baf0bc245e9184d3fdffa9c46f"
+                "reference": "4118013a4d0f97356eae8e7fb2f6c6472575d1df"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/3dcf38ca72b158baf0bc245e9184d3fdffa9c46f",
-                "reference": "3dcf38ca72b158baf0bc245e9184d3fdffa9c46f",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/4118013a4d0f97356eae8e7fb2f6c6472575d1df",
+                "reference": "4118013a4d0f97356eae8e7fb2f6c6472575d1df",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.3.3 || ^7.0"
+                "php": "^7.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.0"
+                "phpunit/phpunit": "^9.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0-dev"
+                    "dev-master": "3.0-dev"
                 }
             },
             "autoload": {
@@ -693,7 +754,7 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "email": "sb@sebastian-bergmann.de",
+                    "email": "sebastian@phpunit.de",
                     "role": "lead"
                 }
             ],
@@ -702,33 +763,33 @@
             "keywords": [
                 "timer"
             ],
-            "time": "2017-02-26T11:10:40+00:00"
+            "time": "2020-02-07T06:08:11+00:00"
         },
         {
             "name": "phpunit/php-token-stream",
-            "version": "2.0.2",
+            "version": "4.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-token-stream.git",
-                "reference": "791198a2c6254db10131eecfe8c06670700904db"
+                "reference": "b2560a0c33f7710e4d7f8780964193e8e8f8effe"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/791198a2c6254db10131eecfe8c06670700904db",
-                "reference": "791198a2c6254db10131eecfe8c06670700904db",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/b2560a0c33f7710e4d7f8780964193e8e8f8effe",
+                "reference": "b2560a0c33f7710e4d7f8780964193e8e8f8effe",
                 "shasum": ""
             },
             "require": {
                 "ext-tokenizer": "*",
-                "php": "^7.0"
+                "php": "^7.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.2.4"
+                "phpunit/phpunit": "^9.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0-dev"
+                    "dev-master": "4.0-dev"
                 }
             },
             "autoload": {
@@ -751,57 +812,56 @@
             "keywords": [
                 "tokenizer"
             ],
-            "time": "2017-11-27T05:48:46+00:00"
+            "time": "2020-02-07T06:19:00+00:00"
         },
         {
             "name": "phpunit/phpunit",
-            "version": "6.3.1",
+            "version": "9.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "c0ff817b36a827e64bf5f57bc72278150cf30a77"
+                "reference": "68d7e5b17a6b9461e17c00446caa409863154f76"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/c0ff817b36a827e64bf5f57bc72278150cf30a77",
-                "reference": "c0ff817b36a827e64bf5f57bc72278150cf30a77",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/68d7e5b17a6b9461e17c00446caa409863154f76",
+                "reference": "68d7e5b17a6b9461e17c00446caa409863154f76",
                 "shasum": ""
             },
             "require": {
+                "doctrine/instantiator": "^1.2.0",
                 "ext-dom": "*",
                 "ext-json": "*",
                 "ext-libxml": "*",
                 "ext-mbstring": "*",
                 "ext-xml": "*",
-                "myclabs/deep-copy": "^1.6.1",
-                "phar-io/manifest": "^1.0.1",
-                "phar-io/version": "^1.0",
-                "php": "^7.0",
-                "phpspec/prophecy": "^1.7",
-                "phpunit/php-code-coverage": "^5.2.2",
-                "phpunit/php-file-iterator": "^1.4.2",
-                "phpunit/php-text-template": "^1.2.1",
-                "phpunit/php-timer": "^1.0.9",
-                "phpunit/phpunit-mock-objects": "^4.0.3",
-                "sebastian/comparator": "^2.0.2",
-                "sebastian/diff": "^2.0",
-                "sebastian/environment": "^3.1",
-                "sebastian/exporter": "^3.1",
-                "sebastian/global-state": "^2.0",
-                "sebastian/object-enumerator": "^3.0.3",
-                "sebastian/resource-operations": "^1.0",
-                "sebastian/version": "^2.0.1"
-            },
-            "conflict": {
-                "phpdocumentor/reflection-docblock": "3.0.2",
-                "phpunit/dbunit": "<3.0"
+                "ext-xmlwriter": "*",
+                "myclabs/deep-copy": "^1.9.1",
+                "phar-io/manifest": "^1.0.3",
+                "phar-io/version": "^2.0.1",
+                "php": "^7.3",
+                "phpspec/prophecy": "^1.8.1",
+                "phpunit/php-code-coverage": "^8.0",
+                "phpunit/php-file-iterator": "^3.0",
+                "phpunit/php-invoker": "^3.0",
+                "phpunit/php-text-template": "^2.0",
+                "phpunit/php-timer": "^3.0",
+                "sebastian/comparator": "^4.0",
+                "sebastian/diff": "^4.0",
+                "sebastian/environment": "^5.0",
+                "sebastian/exporter": "^4.0",
+                "sebastian/global-state": "^4.0",
+                "sebastian/object-enumerator": "^4.0",
+                "sebastian/resource-operations": "^3.0",
+                "sebastian/type": "^2.0",
+                "sebastian/version": "^3.0"
             },
             "require-dev": {
                 "ext-pdo": "*"
             },
             "suggest": {
-                "ext-xdebug": "*",
-                "phpunit/php-invoker": "^1.1"
+                "ext-soap": "*",
+                "ext-xdebug": "*"
             },
             "bin": [
                 "phpunit"
@@ -809,12 +869,15 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "6.3.x-dev"
+                    "dev-master": "9.0-dev"
                 }
             },
             "autoload": {
                 "classmap": [
                     "src/"
+                ],
+                "files": [
+                    "src/Framework/Assert/Functions.php"
                 ]
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -824,8 +887,8 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "role": "lead",
-                    "email": "sebastian@phpunit.de"
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
                 }
             ],
             "description": "The PHP Unit Testing framework.",
@@ -835,92 +898,32 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2017-09-24T07:25:54+00:00"
-        },
-        {
-            "name": "phpunit/phpunit-mock-objects",
-            "version": "4.0.4",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/phpunit-mock-objects.git",
-                "reference": "2f789b59ab89669015ad984afa350c4ec577ade0"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/2f789b59ab89669015ad984afa350c4ec577ade0",
-                "reference": "2f789b59ab89669015ad984afa350c4ec577ade0",
-                "shasum": ""
-            },
-            "require": {
-                "doctrine/instantiator": "^1.0.5",
-                "php": "^7.0",
-                "phpunit/php-text-template": "^1.2.1",
-                "sebastian/exporter": "^3.0"
-            },
-            "conflict": {
-                "phpunit/phpunit": "<6.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^6.0"
-            },
-            "suggest": {
-                "ext-soap": "*"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "4.0.x-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sb@sebastian-bergmann.de",
-                    "role": "lead"
-                }
-            ],
-            "description": "Mock Object library for PHPUnit",
-            "homepage": "https://github.com/sebastianbergmann/phpunit-mock-objects/",
-            "keywords": [
-                "mock",
-                "xunit"
-            ],
-            "abandoned": true,
-            "time": "2017-08-03T14:08:16+00:00"
+            "time": "2020-02-13T07:30:12+00:00"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",
-            "version": "1.0.1",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
-                "reference": "4419fcdb5eabb9caa61a27c7a1db532a6b55dd18"
+                "reference": "5b5dbe0044085ac41df47e79d34911a15b96d82e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/4419fcdb5eabb9caa61a27c7a1db532a6b55dd18",
-                "reference": "4419fcdb5eabb9caa61a27c7a1db532a6b55dd18",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/5b5dbe0044085ac41df47e79d34911a15b96d82e",
+                "reference": "5b5dbe0044085ac41df47e79d34911a15b96d82e",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.6 || ^7.0"
+                "php": "^7.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^5.7 || ^6.0"
+                "phpunit/phpunit": "^9.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "2.0-dev"
                 }
             },
             "autoload": {
@@ -940,34 +943,34 @@
             ],
             "description": "Looks up which function or method a line of code belongs to",
             "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
-            "time": "2017-03-04T06:30:41+00:00"
+            "time": "2020-02-07T06:20:13+00:00"
         },
         {
             "name": "sebastian/comparator",
-            "version": "2.1.3",
+            "version": "4.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "34369daee48eafb2651bea869b4b15d75ccc35f9"
+                "reference": "85b3435da967696ed618ff745f32be3ff4a2b8e8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/34369daee48eafb2651bea869b4b15d75ccc35f9",
-                "reference": "34369daee48eafb2651bea869b4b15d75ccc35f9",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/85b3435da967696ed618ff745f32be3ff4a2b8e8",
+                "reference": "85b3435da967696ed618ff745f32be3ff4a2b8e8",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.0",
-                "sebastian/diff": "^2.0 || ^3.0",
-                "sebastian/exporter": "^3.1"
+                "php": "^7.3",
+                "sebastian/diff": "^4.0",
+                "sebastian/exporter": "^4.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.4"
+                "phpunit/phpunit": "^9.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.1.x-dev"
+                    "dev-master": "4.0-dev"
                 }
             },
             "autoload": {
@@ -980,6 +983,10 @@
                 "BSD-3-Clause"
             ],
             "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
                 {
                     "name": "Jeff Welch",
                     "email": "whatthejeff@gmail.com"
@@ -991,10 +998,6 @@
                 {
                     "name": "Bernhard Schussek",
                     "email": "bschussek@2bepublished.at"
-                },
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
                 }
             ],
             "description": "Provides the functionality to compare PHP values for equality",
@@ -1004,32 +1007,33 @@
                 "compare",
                 "equality"
             ],
-            "time": "2018-02-01T13:46:46+00:00"
+            "time": "2020-02-07T06:08:51+00:00"
         },
         {
             "name": "sebastian/diff",
-            "version": "2.0.1",
+            "version": "4.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "347c1d8b49c5c3ee30c7040ea6fc446790e6bddd"
+                "reference": "c0c26c9188b538bfa985ae10c9f05d278f12060d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/347c1d8b49c5c3ee30c7040ea6fc446790e6bddd",
-                "reference": "347c1d8b49c5c3ee30c7040ea6fc446790e6bddd",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/c0c26c9188b538bfa985ae10c9f05d278f12060d",
+                "reference": "c0c26c9188b538bfa985ae10c9f05d278f12060d",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.0"
+                "php": "^7.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.2"
+                "phpunit/phpunit": "^9.0",
+                "symfony/process": "^4 || ^5"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0-dev"
+                    "dev-master": "4.0-dev"
                 }
             },
             "autoload": {
@@ -1043,45 +1047,51 @@
             ],
             "authors": [
                 {
-                    "name": "Kore Nordmann",
-                    "email": "mail@kore-nordmann.de"
-                },
-                {
                     "name": "Sebastian Bergmann",
                     "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Kore Nordmann",
+                    "email": "mail@kore-nordmann.de"
                 }
             ],
             "description": "Diff implementation",
             "homepage": "https://github.com/sebastianbergmann/diff",
             "keywords": [
-                "diff"
+                "diff",
+                "udiff",
+                "unidiff",
+                "unified diff"
             ],
-            "time": "2017-08-03T08:09:46+00:00"
+            "time": "2020-02-07T06:09:38+00:00"
         },
         {
             "name": "sebastian/environment",
-            "version": "3.1.0",
+            "version": "5.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "cd0871b3975fb7fc44d11314fd1ee20925fce4f5"
+                "reference": "9bffdefa7810031a165ddd6275da6a2c1f6f2dfb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/cd0871b3975fb7fc44d11314fd1ee20925fce4f5",
-                "reference": "cd0871b3975fb7fc44d11314fd1ee20925fce4f5",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/9bffdefa7810031a165ddd6275da6a2c1f6f2dfb",
+                "reference": "9bffdefa7810031a165ddd6275da6a2c1f6f2dfb",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.0"
+                "php": "^7.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.1"
+                "phpunit/phpunit": "^9.0"
+            },
+            "suggest": {
+                "ext-posix": "*"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.1.x-dev"
+                    "dev-master": "5.0-dev"
                 }
             },
             "autoload": {
@@ -1106,34 +1116,34 @@
                 "environment",
                 "hhvm"
             ],
-            "time": "2017-07-01T08:51:00+00:00"
+            "time": "2020-02-19T13:40:20+00:00"
         },
         {
             "name": "sebastian/exporter",
-            "version": "3.1.0",
+            "version": "4.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "234199f4528de6d12aaa58b612e98f7d36adb937"
+                "reference": "80c26562e964016538f832f305b2286e1ec29566"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/234199f4528de6d12aaa58b612e98f7d36adb937",
-                "reference": "234199f4528de6d12aaa58b612e98f7d36adb937",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/80c26562e964016538f832f305b2286e1ec29566",
+                "reference": "80c26562e964016538f832f305b2286e1ec29566",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.0",
-                "sebastian/recursion-context": "^3.0"
+                "php": "^7.3",
+                "sebastian/recursion-context": "^4.0"
             },
             "require-dev": {
                 "ext-mbstring": "*",
-                "phpunit/phpunit": "^6.0"
+                "phpunit/phpunit": "^9.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.1.x-dev"
+                    "dev-master": "4.0-dev"
                 }
             },
             "autoload": {
@@ -1147,6 +1157,10 @@
             ],
             "authors": [
                 {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
                     "name": "Jeff Welch",
                     "email": "whatthejeff@gmail.com"
                 },
@@ -1155,16 +1169,12 @@
                     "email": "github@wallbash.com"
                 },
                 {
-                    "name": "Bernhard Schussek",
-                    "email": "bschussek@2bepublished.at"
-                },
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
-                },
-                {
                     "name": "Adam Harvey",
                     "email": "aharvey@php.net"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
                 }
             ],
             "description": "Provides the functionality to export PHP variables for visualization",
@@ -1173,27 +1183,30 @@
                 "export",
                 "exporter"
             ],
-            "time": "2017-04-03T13:19:02+00:00"
+            "time": "2020-02-07T06:10:52+00:00"
         },
         {
             "name": "sebastian/global-state",
-            "version": "2.0.0",
+            "version": "4.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/global-state.git",
-                "reference": "e8ba02eed7bbbb9e59e43dedd3dddeff4a56b0c4"
+                "reference": "bdb1e7c79e592b8c82cb1699be3c8743119b8a72"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/e8ba02eed7bbbb9e59e43dedd3dddeff4a56b0c4",
-                "reference": "e8ba02eed7bbbb9e59e43dedd3dddeff4a56b0c4",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/bdb1e7c79e592b8c82cb1699be3c8743119b8a72",
+                "reference": "bdb1e7c79e592b8c82cb1699be3c8743119b8a72",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.0"
+                "php": "^7.3",
+                "sebastian/object-reflector": "^2.0",
+                "sebastian/recursion-context": "^4.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.0"
+                "ext-dom": "*",
+                "phpunit/phpunit": "^9.0"
             },
             "suggest": {
                 "ext-uopz": "*"
@@ -1201,7 +1214,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0-dev"
+                    "dev-master": "4.0-dev"
                 }
             },
             "autoload": {
@@ -1224,34 +1237,34 @@
             "keywords": [
                 "global state"
             ],
-            "time": "2017-04-27T15:39:26+00:00"
+            "time": "2020-02-07T06:11:37+00:00"
         },
         {
             "name": "sebastian/object-enumerator",
-            "version": "3.0.3",
+            "version": "4.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/object-enumerator.git",
-                "reference": "7cfd9e65d11ffb5af41198476395774d4c8a84c5"
+                "reference": "e67516b175550abad905dc952f43285957ef4363"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/7cfd9e65d11ffb5af41198476395774d4c8a84c5",
-                "reference": "7cfd9e65d11ffb5af41198476395774d4c8a84c5",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/e67516b175550abad905dc952f43285957ef4363",
+                "reference": "e67516b175550abad905dc952f43285957ef4363",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.0",
-                "sebastian/object-reflector": "^1.1.1",
-                "sebastian/recursion-context": "^3.0"
+                "php": "^7.3",
+                "sebastian/object-reflector": "^2.0",
+                "sebastian/recursion-context": "^4.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.0"
+                "phpunit/phpunit": "^9.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0.x-dev"
+                    "dev-master": "4.0-dev"
                 }
             },
             "autoload": {
@@ -1271,32 +1284,32 @@
             ],
             "description": "Traverses array structures and object graphs to enumerate all referenced objects",
             "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
-            "time": "2017-08-03T12:35:26+00:00"
+            "time": "2020-02-07T06:12:23+00:00"
         },
         {
             "name": "sebastian/object-reflector",
-            "version": "1.1.1",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/object-reflector.git",
-                "reference": "773f97c67f28de00d397be301821b06708fca0be"
+                "reference": "f4fd0835cabb0d4a6546d9fe291e5740037aa1e7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/773f97c67f28de00d397be301821b06708fca0be",
-                "reference": "773f97c67f28de00d397be301821b06708fca0be",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/f4fd0835cabb0d4a6546d9fe291e5740037aa1e7",
+                "reference": "f4fd0835cabb0d4a6546d9fe291e5740037aa1e7",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.0"
+                "php": "^7.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.0"
+                "phpunit/phpunit": "^9.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.1-dev"
+                    "dev-master": "2.0-dev"
                 }
             },
             "autoload": {
@@ -1316,32 +1329,32 @@
             ],
             "description": "Allows reflection of object attributes, including inherited and non-public ones",
             "homepage": "https://github.com/sebastianbergmann/object-reflector/",
-            "time": "2017-03-29T09:07:27+00:00"
+            "time": "2020-02-07T06:19:40+00:00"
         },
         {
             "name": "sebastian/recursion-context",
-            "version": "3.0.0",
+            "version": "4.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/recursion-context.git",
-                "reference": "5b0cd723502bac3b006cbf3dbf7a1e3fcefe4fa8"
+                "reference": "cdd86616411fc3062368b720b0425de10bd3d579"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/5b0cd723502bac3b006cbf3dbf7a1e3fcefe4fa8",
-                "reference": "5b0cd723502bac3b006cbf3dbf7a1e3fcefe4fa8",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/cdd86616411fc3062368b720b0425de10bd3d579",
+                "reference": "cdd86616411fc3062368b720b0425de10bd3d579",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.0"
+                "php": "^7.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.0"
+                "phpunit/phpunit": "^9.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0.x-dev"
+                    "dev-master": "4.0-dev"
                 }
             },
             "autoload": {
@@ -1355,12 +1368,12 @@
             ],
             "authors": [
                 {
-                    "name": "Jeff Welch",
-                    "email": "whatthejeff@gmail.com"
-                },
-                {
                     "name": "Sebastian Bergmann",
                     "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
                 },
                 {
                     "name": "Adam Harvey",
@@ -1369,29 +1382,32 @@
             ],
             "description": "Provides functionality to recursively process PHP variables",
             "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
-            "time": "2017-03-03T06:23:57+00:00"
+            "time": "2020-02-07T06:18:20+00:00"
         },
         {
             "name": "sebastian/resource-operations",
-            "version": "1.0.0",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/resource-operations.git",
-                "reference": "ce990bb21759f94aeafd30209e8cfcdfa8bc3f52"
+                "reference": "8c98bf0dfa1f9256d0468b9803a1e1df31b6fa98"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/ce990bb21759f94aeafd30209e8cfcdfa8bc3f52",
-                "reference": "ce990bb21759f94aeafd30209e8cfcdfa8bc3f52",
+                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/8c98bf0dfa1f9256d0468b9803a1e1df31b6fa98",
+                "reference": "8c98bf0dfa1f9256d0468b9803a1e1df31b6fa98",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.6.0"
+                "php": "^7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "3.0-dev"
                 }
             },
             "autoload": {
@@ -1411,29 +1427,75 @@
             ],
             "description": "Provides a list of PHP built-in functions that operate on resources",
             "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
-            "time": "2015-07-28T20:34:47+00:00"
+            "time": "2020-02-07T06:13:02+00:00"
         },
         {
-            "name": "sebastian/version",
-            "version": "2.0.1",
+            "name": "sebastian/type",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sebastianbergmann/version.git",
-                "reference": "99732be0ddb3361e16ad77b68ba41efc8e979019"
+                "url": "https://github.com/sebastianbergmann/type.git",
+                "reference": "9e8f42f740afdea51f5f4e8cec2035580e797ee1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/99732be0ddb3361e16ad77b68ba41efc8e979019",
-                "reference": "99732be0ddb3361e16ad77b68ba41efc8e979019",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/9e8f42f740afdea51f5f4e8cec2035580e797ee1",
+                "reference": "9e8f42f740afdea51f5f4e8cec2035580e797ee1",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.6"
+                "php": "^7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0.x-dev"
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Collection of value objects that represent the types of the PHP type system",
+            "homepage": "https://github.com/sebastianbergmann/type",
+            "time": "2020-02-07T06:13:43+00:00"
+        },
+        {
+            "name": "sebastian/version",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/version.git",
+                "reference": "0411bde656dce64202b39c2f4473993a9081d39e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/0411bde656dce64202b39c2f4473993a9081d39e",
+                "reference": "0411bde656dce64202b39c2f4473993a9081d39e",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
                 }
             },
             "autoload": {
@@ -1454,20 +1516,20 @@
             ],
             "description": "Library that helps with managing the version number of Git-hosted PHP projects",
             "homepage": "https://github.com/sebastianbergmann/version",
-            "time": "2016-10-03T07:35:21+00:00"
+            "time": "2020-01-21T06:36:37+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.11.0",
+            "version": "v1.14.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "82ebae02209c21113908c229e9883c419720738a"
+                "reference": "fbdeaec0df06cf3d51c93de80c7eb76e271f5a38"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/82ebae02209c21113908c229e9883c419720738a",
-                "reference": "82ebae02209c21113908c229e9883c419720738a",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/fbdeaec0df06cf3d51c93de80c7eb76e271f5a38",
+                "reference": "fbdeaec0df06cf3d51c93de80c7eb76e271f5a38",
                 "shasum": ""
             },
             "require": {
@@ -1479,7 +1541,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.11-dev"
+                    "dev-master": "1.14-dev"
                 }
             },
             "autoload": {
@@ -1496,12 +1558,12 @@
             ],
             "authors": [
                 {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                },
-                {
                     "name": "Gert de Pagter",
                     "email": "BackEndTea@gmail.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
                 }
             ],
             "description": "Symfony polyfill for ctype functions",
@@ -1512,7 +1574,7 @@
                 "polyfill",
                 "portable"
             ],
-            "time": "2019-02-06T07:57:58+00:00"
+            "time": "2020-01-13T11:15:53+00:00"
         },
         {
             "name": "theseer/tokenizer",
@@ -1556,32 +1618,29 @@
         },
         {
             "name": "webmozart/assert",
-            "version": "1.4.0",
+            "version": "1.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/webmozart/assert.git",
-                "reference": "83e253c8e0be5b0257b881e1827274667c5c17a9"
+                "reference": "aed98a490f9a8f78468232db345ab9cf606cf598"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webmozart/assert/zipball/83e253c8e0be5b0257b881e1827274667c5c17a9",
-                "reference": "83e253c8e0be5b0257b881e1827274667c5c17a9",
+                "url": "https://api.github.com/repos/webmozart/assert/zipball/aed98a490f9a8f78468232db345ab9cf606cf598",
+                "reference": "aed98a490f9a8f78468232db345ab9cf606cf598",
                 "shasum": ""
             },
             "require": {
                 "php": "^5.3.3 || ^7.0",
                 "symfony/polyfill-ctype": "^1.8"
             },
+            "conflict": {
+                "vimeo/psalm": "<3.6.0"
+            },
             "require-dev": {
-                "phpunit/phpunit": "^4.6",
-                "sebastian/version": "^1.0.1"
+                "phpunit/phpunit": "^4.8.36 || ^7.5.13"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.3-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "Webmozart\\Assert\\": "src/"
@@ -1603,7 +1662,7 @@
                 "check",
                 "validate"
             ],
-            "time": "2018-12-25T11:19:39+00:00"
+            "time": "2020-02-14T12:15:55+00:00"
         }
     ],
     "aliases": [],
@@ -1612,7 +1671,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=7.0"
+        "php": "~7.3.0"
     },
     "platform-dev": []
 }

--- a/src/Exception/InvalidOpt.php
+++ b/src/Exception/InvalidOpt.php
@@ -1,7 +1,0 @@
-<?php
-
-namespace PageMill\Router\Exception;
-
-class InvalidOpt extends \Exception
-{
-}

--- a/src/Normalize.php
+++ b/src/Normalize.php
@@ -29,7 +29,7 @@ class Normalize {
      *
      * @return void
      */
-    public static function ending_slash($request_path, array $excludes = array()) {
+    public static function endingSlash(string $request_path, array $excludes = array()) {
 
         foreach ($excludes as $regex) {
             if (preg_match($regex, $request_path)) {
@@ -49,17 +49,16 @@ class Normalize {
 
     /**
      * Normalizes the path. This can be used to remove file names like
-     * index.html or add them. Also, any prefixes of the URL path that should
-     * be removed such as a sub-directory common to all paths.
+     * index.html or add them.
      *
-     * @param  string $request_path     URL path.
-     * @param  array  $directory_index  Array of file names to be removed from
-     *                                  the end of paths leaving only a / at
-     *                                  the end of the path.
+     * @param  string $request_path    URL path.
+     * @param  array  $directory_index Array of file names to be removed from
+     *                                 the end of paths leaving only a / at
+     *                                 the end of the path.
      *
      * @return string
      */
-    public static function directory_index($request_path, array $directory_index) {
+    public static function directoryIndex(string $request_path, array $directory_index): string {
 
         if (!empty($directory_index)) {
             foreach ($directory_index as $path) {
@@ -75,9 +74,9 @@ class Normalize {
     }
 
     /**
-     * Normalizes the path. This can be used to remove file names like
-     * index.html or add them. Also, any prefixes of the URL path that should
-     * be removed such as a sub-directory common to all paths.
+     * Normalizes the path by removing any prefixes of the URL path such as a
+     * sub-directory common to all paths. This is useful when using
+     * pre-defined routes where the application may exist in a sub-directory.
      *
      * @param  string $request_path     URL path.
      * @param  array  $prefixes         Array of strings to be removed from the
@@ -87,7 +86,7 @@ class Normalize {
      *
      * @return string
      */
-    public static function prefix($request_path, array $prefixes) {
+    public static function prefix(string $request_path, array $prefixes): string {
 
         if (!empty($prefixes)) {
             foreach ($prefixes as $path) {

--- a/tests/NormalizeTest.php
+++ b/tests/NormalizeTest.php
@@ -6,7 +6,7 @@ class NormalizeTest extends \PHPUnit\Framework\TestCase {
 
     public function testPathDirectoryIndex() {
         $request_path = "/foo/bar/index.html";
-        $request_path = Normalize::directory_index(
+        $request_path = Normalize::directoryIndex(
             $request_path,
             array(
                 "index.html"
@@ -46,7 +46,7 @@ class NormalizeTest extends \PHPUnit\Framework\TestCase {
 
     public function testEndingSlash() {
         $request_path = "/foo/bar";
-        $request_path = Normalize::ending_slash(
+        $request_path = Normalize::endingSlash(
             $request_path
         );
         $this->assertEquals(
@@ -57,7 +57,7 @@ class NormalizeTest extends \PHPUnit\Framework\TestCase {
 
     public function testEndingSlashExcludes() {
         $request_path = "/foo/bar/baz";
-        $request_path = Normalize::ending_slash(
+        $request_path = Normalize::endingSlash(
             $request_path,
             array(
                 "!^/foo/bar/baz!"

--- a/tests/RouterTest.php
+++ b/tests/RouterTest.php
@@ -6,47 +6,47 @@ class RouterTest extends \PHPUnit\Framework\TestCase {
 
     public function testConstructor() {
         $r = new Router(
-            array(
-                array(
+            [
+                [
                     "type" => "exact",
                     "pattern" => "/foo",
                     "action" => "Foo",
-                    "tokens" => array()
-                ),
-                array(
+                    "tokens" => []
+                ],
+                [
                     "type" => "exact",
                     "pattern" => "/foo/bar",
                     "action" => "FooBar",
-                    "tokens" => array()
-                ),
-            )
+                    "tokens" => []
+                ],
+            ]
         );
 
         $route = $r->match("/foo");
         $this->assertEquals(
-            array(
+            [
                 "type" => "exact",
                 "pattern" => "/foo",
                 "action" => "Foo",
-                "tokens" => array()
-            ),
+                "tokens" => []
+            ],
             $route
         );
 
         $route = $r->match("/foo/bar");
         $this->assertEquals(
-            array(
+            [
                 "type" => "exact",
                 "pattern" => "/foo/bar",
                 "action" => "FooBar",
-                "tokens" => array()
-            ),
+                "tokens" => []
+            ],
             $route
         );
 
         $route = $r->match("/foo/bar/baz");
         $this->assertEquals(
-            false,
+            [],
             $route
         );
     }
@@ -59,17 +59,66 @@ class RouterTest extends \PHPUnit\Framework\TestCase {
             "/foo",
             "Foo"
         );
-        $routes = $r->get_routes();
+        $routes = $r->getRoutes();
         $this->assertEquals(
-            array(
-                array(
+            [
+                [
                     "type" => "exact",
                     "pattern" => "/foo",
                     "action" => "Foo"
-                )
-            ),
+                ]
+            ],
             $routes
         );
+    }
+
+    public function testCreateRoute() {
+        $r = new Router();
+        $route = $r->createRoute(
+            "exact",
+            "/foo",
+            [
+                "accept"  => "text/html",
+                "action"  => "Foo",
+                "headers" => [
+                    "X-Foo"
+                ],
+                "host"    => "www.example.com",
+                "method"  => "GET",
+                "tokens"  => [
+                    "foo"
+                ],
+            ]
+        );
+
+        $this->assertEquals(
+            [
+                "type" => "exact",
+                "pattern" => "/foo",
+                "accept"  => "text/html",
+                "action"  => "Foo",
+                "headers" => [
+                    "X-Foo"
+                ],
+                "host"    => "www.example.com",
+                "method"  => "GET",
+                "tokens"  => [
+                    "foo"
+                ],
+            ],
+            $route
+        );
+
+        $this->expectException(\PageMill\Router\Exception\InvalidRoute::class);
+
+        $route = $r->createRoute(
+            "exact",
+            "/foo",
+            [
+                "bad-value" => true,
+            ]
+        );
+
     }
 
     public function testMatch() {
@@ -87,23 +136,23 @@ class RouterTest extends \PHPUnit\Framework\TestCase {
 
         $route = $r->match("/foo/bar");
         $this->assertEquals(
-            array(
+            [
                 "type" => "exact",
                 "pattern" => "/foo/bar",
                 "action" => "FooBar",
-                "tokens" => array()
-            ),
+                "tokens" => []
+            ],
             $route
         );
 
         $route = $r->match("/foo");
         $this->assertEquals(
-            array(
+            [
                 "type" => "exact",
                 "pattern" => "/foo",
                 "action" => "Foo",
-                "tokens" => array()
-            ),
+                "tokens" => []
+            ],
             $route
         );
 
@@ -124,11 +173,11 @@ class RouterTest extends \PHPUnit\Framework\TestCase {
 
         $route = $r->match("/foo/bar");
         $this->assertEquals(
-            array(
+            [
                 "type" => "default",
                 "pattern" => "",
                 "action" => "FooBar",
-            ),
+            ],
             $route
         );
     }
@@ -147,30 +196,30 @@ class RouterTest extends \PHPUnit\Framework\TestCase {
         );
         $route = $r->match("/foo/bar/baz");
         $this->assertEquals(
-            false,
+            [],
             $route
         );
     }
 
     public function testRouteMatch() {
         $r = new Router();
-        $route = $r->match_route(
-            array(
+        $route = $r->matchRoute(
+            [
                 "type" => "exact",
                 "pattern" => "/foo/bar",
                 "action" => "FooBar"
-            ),
+            ],
             "/foo/bar",
-            array(),
-            array()
+            [],
+            []
         );
         $this->assertEquals(
-            array(
+            [
                 "type" => "exact",
                 "pattern" => "/foo/bar",
                 "action" => "FooBar",
-                "tokens" => array()
-            ),
+                "tokens" => []
+            ],
             $route
         );
     }
@@ -179,32 +228,32 @@ class RouterTest extends \PHPUnit\Framework\TestCase {
         $r = new Router();
         $route = $r->match(
             "/foo/bar",
-            array(
-                array(
+            [
+                [
                     "type" => "starts_with",
                     "pattern" => "/foo",
-                    "routes" => array(
-                        array(
+                    "routes" => [
+                        [
                             "type" => "exact",
                             "pattern" => "/foo/bar",
                             "action" => "FooBar"
-                        ),
-                        array(
+                        ],
+                        [
                             "type" => "exact",
                             "pattern" => "/foo/baz",
                             "action" => "FooBaz"
-                        ),
-                    )
-                )
-            )
+                        ],
+                    ]
+                ]
+            ]
         );
         $this->assertEquals(
-            array(
+            [
                 "type" => "exact",
                 "pattern" => "/foo/bar",
                 "action" => "FooBar",
-                "tokens" => array()
-            ),
+                "tokens" => []
+            ],
             $route
         );
     }
@@ -213,170 +262,170 @@ class RouterTest extends \PHPUnit\Framework\TestCase {
         $r = new Router();
         $route = $r->match(
             "/foo/ber",
-            array(
-                array(
+            [
+                [
                     "type" => "starts_with",
                     "pattern" => "/foo",
-                    "routes" => array(
-                        array(
+                    "routes" => [
+                        [
                             "type" => "exact",
                             "pattern" => "/foo/bar",
                             "action" => "FooBar"
-                        ),
-                        array(
+                        ],
+                        [
                             "type" => "exact",
                             "pattern" => "/foo/baz",
                             "action" => "FooBaz"
-                        ),
-                    )
-                )
-            )
+                        ],
+                    ]
+                ]
+            ]
         );
         $this->assertEquals(
-            false,
+            [],
             $route
         );
     }
 
     public function testRouteNoMatch() {
         $r = new Router();
-        $route = $r->match_route(
-            array(
+        $route = $r->matchRoute(
+            [
                 "type" => "exact",
                 "pattern" => "/foo/bar",
                 "action" => "FooBar"
-            ),
+            ],
             "/foo",
-            array(),
-            array()
+            [],
+            []
         );
         $this->assertEquals(
-            false,
+            [],
             $route
         );
     }
 
     public function testPathMatch() {
         $r = new Router();
-        $route = array(
+        $route = [
             "type" => "exact",
             "pattern" => "/foo/bar",
             "action" => "FooBar",
             "method" => "GET"
-        );
+        ];
 
-        $resp = $r->match_path(
+        $resp = $r->matchPath(
             $route,
             "/foo/bar"
         );
         $this->assertEquals(
-            array(
+            [
                 "type" => "exact",
                 "pattern" => "/foo/bar",
                 "action" => "FooBar",
                 "method" => "GET",
-                "tokens" => array()
-            ),
+                "tokens" => []
+            ],
             $resp
         );
     }
 
     public function testPathNoMatch() {
         $r = new Router();
-        $route = array(
+        $route = [
             "type" => "exact",
             "pattern" => "/foo/bar",
             "action" => "FooBar",
             "method" => "GET"
-        );
+        ];
 
-        $resp = $r->match_path(
+        $resp = $r->matchPath(
             $route,
             "/foo"
         );
         $this->assertEquals(
-            false,
+            [],
             $resp
         );
     }
 
     public function testPathTokenStartsWithMatch() {
         $r = new Router();
-        $route = array(
+        $route = [
             "type" => "starts_with",
             "pattern" => "/foo/bar",
             "action" => "FooBar",
             "method" => "GET"
-        );
+        ];
 
-        $resp = $r->match_path(
+        $resp = $r->matchPath(
             $route,
             "/foo/bar/1/"
         );
         $this->assertEquals(
-            array(
+            [
                 "type" => "starts_with",
                 "pattern" => "/foo/bar",
                 "action" => "FooBar",
                 "method" => "GET",
-                "tokens" => array(
+                "tokens" => [
                     "1"
-                )
-            ),
+                ]
+            ],
             $resp
         );
 
-        $resp = $r->match_path(
+        $resp = $r->matchPath(
             $route,
             "/foo/bar/1/2/"
         );
         $this->assertEquals(
-            array(
+            [
                 "type" => "starts_with",
                 "pattern" => "/foo/bar",
                 "action" => "FooBar",
                 "method" => "GET",
-                "tokens" => array(
+                "tokens" => [
                     "1",
                     "2"
-                )
-            ),
+                ]
+            ],
             $resp
         );
 
-        $route = array(
+        $route = [
             "type" => "starts_with",
             "pattern" => "/foo/bar",
             "action" => "FooBar",
             "method" => "GET",
-            "tokens" => array(
+            "tokens" => [
                 "id"
-            )
-        );
+            ]
+        ];
 
-        $resp = $r->match_path(
+        $resp = $r->matchPath(
             $route,
             "/foo/bar/1/"
         );
         $this->assertEquals(
-            array(
+            [
                 "type" => "starts_with",
                 "pattern" => "/foo/bar",
                 "action" => "FooBar",
                 "method" => "GET",
-                "tokens" => array(
+                "tokens" => [
                     "id" => "1",
-                )
-            ),
+                ]
+            ],
             $resp
         );
 
-        $resp = $r->match_path(
+        $resp = $r->matchPath(
             $route,
             "/foo/bar/1/2/"
         );
         $this->assertEquals(
-            false,
+            [],
             $resp
         );
     }
@@ -384,106 +433,106 @@ class RouterTest extends \PHPUnit\Framework\TestCase {
 
     public function testPathTokenRegexMatch() {
         $r = new Router();
-        $route = array(
+        $route = [
             "type" => "regex",
             "pattern" => "!/foo/bar/(\d+)/!",
             "action" => "FooBar",
             "method" => "GET"
-        );
+        ];
 
-        $resp = $r->match_path(
+        $resp = $r->matchPath(
             $route,
             "/foo/bar/1/"
         );
         $this->assertEquals(
-            array(
+            [
                 "type" => "regex",
                 "pattern" => "!/foo/bar/(\d+)/!",
                 "action" => "FooBar",
                 "method" => "GET",
-                "tokens" => array(
+                "tokens" => [
                     "1"
-                )
-            ),
+                ]
+            ],
             $resp
         );
 
-        $resp = $r->match_path(
+        $resp = $r->matchPath(
             $route,
             "/foo/bar/1/2/"
         );
         $this->assertEquals(
-            array(
+            [
                 "type" => "regex",
                 "pattern" => "!/foo/bar/(\d+)/!",
                 "action" => "FooBar",
                 "method" => "GET",
-                "tokens" => array(
+                "tokens" => [
                     "1"
-                )
-            ),
+                ]
+            ],
             $resp
         );
 
-        $route = array(
+        $route = [
             "type" => "regex",
             "pattern" => "!/foo/bar/(\d+)/(\d+)/!",
             "action" => "FooBar",
             "method" => "GET"
-        );
+        ];
 
-        $resp = $r->match_path(
+        $resp = $r->matchPath(
             $route,
             "/foo/bar/1/2/"
         );
         $this->assertEquals(
-            array(
+            [
                 "type" => "regex",
                 "pattern" => "!/foo/bar/(\d+)/(\d+)/!",
                 "action" => "FooBar",
                 "method" => "GET",
-                "tokens" => array(
+                "tokens" => [
                     "1",
                     "2"
-                )
-            ),
+                ]
+            ],
             $resp
         );
 
-        $resp = $r->match_path(
+        $resp = $r->matchPath(
             $route,
             "/foo/bar/1/"
         );
         $this->assertEquals(
-            false,
+            [],
             $resp
         );
 
-        $route = array(
+        $route = [
             "type" => "regex",
             "pattern" => "!/foo/bar/(\d+)/(\d+)/!",
             "action" => "FooBar",
             "method" => "GET",
-            "tokens" => array(
+            "tokens" => [
                 "var1",
                 "var2"
-            )
-        );
-        $resp = $r->match_path(
+            ]
+        ];
+        $resp = $r->matchPath(
             $route,
             "/foo/bar/1/2/"
         );
         $this->assertEquals(
-            array(
+            [
                 "type" => "regex",
                 "pattern" => "!/foo/bar/(\d+)/(\d+)/!",
                 "action" => "FooBar",
                 "method" => "GET",
-                "tokens" => array(
+                "tokens" => [
                     "var1" => "1",
                     "var2" => "2"
-                )
-            ),
+                ]
+            ],
             $resp
         );
 
@@ -492,18 +541,18 @@ class RouterTest extends \PHPUnit\Framework\TestCase {
 
     public function testMethodMatch() {
         $r = new Router();
-        $route = array(
+        $route = [
             "type" => "exact",
             "pattern" => "/foo/bar",
             "action" => "FooBar",
             "method" => "GET"
-        );
+        ];
 
-        $resp = $r->match_method(
+        $resp = $r->matchMethod(
             $route,
-            array(
+            [
                 "REQUEST_METHOD" => "GET"
-            )
+            ]
         );
         $this->assertEquals(
             "GET",
@@ -513,60 +562,60 @@ class RouterTest extends \PHPUnit\Framework\TestCase {
 
     public function testMethodNoMatch() {
         $r = new Router();
-        $route = array(
+        $route = [
             "type" => "exact",
             "pattern" => "/foo/bar",
             "action" => "FooBar",
             "method" => "GET"
-        );
+        ];
 
-        $resp = $r->match_method(
+        $resp = $r->matchMethod(
             $route,
-            array(
+            [
                 "REQUEST_METHOD" => "POST"
-            )
+            ]
         );
         $this->assertEquals(
-            false,
+            [],
             $resp
         );
     }
 
     public function testHostMatch() {
         $r = new Router();
-        $route = array(
+        $route = [
             "type" => "exact",
             "pattern" => "/foo/bar",
             "action" => "FooBar",
             "host" => "www.example.com"
-        );
+        ];
 
-        $resp = $r->match_host(
+        $resp = $r->matchHost(
             $route,
-            array(
+            [
                 "HTTP_HOST" => "www.example.com"
-            )
+            ]
         );
         $this->assertEquals(
             "www.example.com",
             $resp["host"]
         );
 
-        $route = array(
+        $route = [
             "type" => "exact",
             "pattern" => "/foo/bar",
             "action" => "FooBar",
-            "host" => array(
+            "host" => [
                 "type" => "regex",
                 "pattern" => '/\.example\.com$/'
-            )
-        );
+            ]
+        ];
 
-        $resp = $r->match_host(
+        $resp = $r->matchHost(
             $route,
-            array(
+            [
                 "HTTP_HOST" => "www.example.com"
-            )
+            ]
         );
         $this->assertEquals(
             "www.example.com",
@@ -577,42 +626,42 @@ class RouterTest extends \PHPUnit\Framework\TestCase {
 
     public function testHostNoMatch() {
         $r = new Router();
-        $route = array(
+        $route = [
             "type" => "exact",
             "pattern" => "/foo/bar",
             "action" => "FooBar",
             "host" => "www.example.com"
-        );
+        ];
 
-        $resp = $r->match_host(
+        $resp = $r->matchHost(
             $route,
-            array(
+            [
                 "HTTP_HOST" => "www2.example.com"
-            )
+            ]
         );
         $this->assertEquals(
-            false,
+            [],
             $resp
         );
 
-        $route = array(
+        $route = [
             "type" => "exact",
             "pattern" => "/foo/bar",
             "action" => "FooBar",
-            "host" => array(
+            "host" => [
                 "type" => "regex",
                 "pattern" => '/\.example\.com$/'
-            )
-        );
+            ]
+        ];
 
-        $resp = $r->match_host(
+        $resp = $r->matchHost(
             $route,
-            array(
+            [
                 "HTTP_HOST" => "www2.example2.com"
-            )
+            ]
         );
         $this->assertEquals(
-            false,
+            [],
             $resp
         );
 
@@ -620,20 +669,20 @@ class RouterTest extends \PHPUnit\Framework\TestCase {
 
     public function testHeaderMatch() {
         $r = new Router();
-        $route = array(
+        $route = [
             "type" => "exact",
             "pattern" => "/foo/bar",
             "action" => "FooBar",
-            "headers" => array(
+            "headers" => [
                 "Host" => "www.example.com"
-            )
-        );
+            ]
+        ];
 
-        $resp = $r->match_headers(
+        $resp = $r->matchHeaders(
             $route,
-            array(
+            [
                 "Host" => "www.example.com"
-            )
+            ]
         );
         $this->assertEquals(
             "www.example.com",
@@ -643,44 +692,44 @@ class RouterTest extends \PHPUnit\Framework\TestCase {
 
     public function testHeaderNoMatch() {
         $r = new Router();
-        $route = array(
+        $route = [
             "type" => "exact",
             "pattern" => "/foo/bar",
             "action" => "FooBar",
-            "headers" => array(
+            "headers" => [
                 "Host" => "www.example.com"
-            )
-        );
+            ]
+        ];
 
-        $resp = $r->match_headers(
+        $resp = $r->matchHeaders(
             $route,
-            array(
+            [
                 "Host" => "www2.example.com"
-            )
+            ]
         );
         $this->assertEquals(
-            false,
+            [],
             $resp
         );
     }
 
     public function testHeadersOnlyReturnMatched() {
         $r = new Router();
-        $route = array(
+        $route = [
             "type" => "exact",
             "pattern" => "/foo/bar",
             "action" => "FooBar",
-            "headers" => array(
+            "headers" => [
                 "Host" => "www.example.com"
-            )
-        );
+            ]
+        ];
 
-        $resp = $r->match_headers(
+        $resp = $r->matchHeaders(
             $route,
-            array(
+            [
                 "Host" => "www.example.com",
                 "X-Foo" => "bar",
-            )
+            ]
         );
         $this->assertEquals(
             1,
@@ -694,20 +743,20 @@ class RouterTest extends \PHPUnit\Framework\TestCase {
 
     public function testHeaderMatchCase() {
         $r = new Router();
-        $route = array(
+        $route = [
             "type" => "exact",
             "pattern" => "/foo/bar",
             "action" => "FooBar",
-            "headers" => array(
+            "headers" => [
                 "host" => "www.example.com"
-            )
-        );
+            ]
+        ];
 
-        $resp = $r->match_headers(
+        $resp = $r->matchHeaders(
             $route,
-            array(
+            [
                 "Host" => "www.example.com"
-            )
+            ]
         );
         $this->assertEquals(
             "www.example.com",
@@ -718,15 +767,15 @@ class RouterTest extends \PHPUnit\Framework\TestCase {
     public function testGetHeaders() {
         $r = new Router();
 
-        $resp = $r->get_headers(
-            array(
+        $resp = $r->getHeaders(
+            [
                 "HTTP_HOST" => "www.example.com"
-            )
+            ]
         );
         $this->assertEquals(
-            array(
+            [
                 "HOST" => "www.example.com"
-            ),
+            ],
             $resp
         );
     }
@@ -734,197 +783,66 @@ class RouterTest extends \PHPUnit\Framework\TestCase {
     public function testAcceptMatch() {
         $r = new Router();
 
-        $route = array(
+        $route = [
             "type" => "exact",
             "pattern" => "/foo/bar",
             "action" => "FooBar",
             "accept" => "text/html"
-        );
-
-        $resp = $r->match_accept(
-            $route,
-            array(
-                "HTTP_ACCEPT" => "text/html;q=0.1"
-            )
-        );
-        $this->assertEquals(
-            "text/html",
-            $resp["accept"]
-        );
-
-        $resp = $r->match_accept(
-            $route,
-            array(
-                "HTTP_ACCEPT" => "application/json;1.0,text/html;q=0.1"
-            )
-        );
-        $this->assertEquals(
-            "text/html",
-            $resp["accept"]
-        );
-
-        $route["accept"] = [
-            "application/json",
-            "text/html"
         ];
 
-    }
+        $resp = $r->matchAccept(
+            $route,
+            [
+                "HTTP_ACCEPT" => "text/html;q=0.1"
+            ]
+        );
+        $this->assertEquals(
+            "text/html",
+            $resp["accept"]
+        );
 
-    public function testAcceptMatchQuality() {
-        $r = new Router();
-
-        $route = array(
+        $route = [
             "type" => "exact",
             "pattern" => "/foo/bar",
             "action" => "FooBar",
-            "accept" => [
-                "application/json",
-                "text/html"
+            "accept" => "text/plain"
+        ];
+
+        $resp = $r->matchAccept(
+            $route,
+            [
+                "HTTP_ACCEPT" => "text/html;q=0.1"
             ]
         );
-
-        $resp = $r->match_accept(
-            $route,
-            array(
-                "HTTP_ACCEPT" => "application/json;q=1.0,text/html;q=0.1"
-            )
-        );
         $this->assertEquals(
-            "application/json",
-            $resp["accept"]
+            [],
+            $resp
         );
-    }
 
-    public function testAcceptMatchEqualQuality() {
-        $r = new Router();
+        $this->expectException(\PageMill\Router\Exception\InvalidMatchType::class);
+        $this->expectExceptionCode(10);
 
-        $route = array(
-            "type" => "exact",
-            "pattern" => "/foo/bar",
-            "action" => "FooBar",
-            "accept" => [
-                "application/json",
-                "text/html"
+        $resp = $r->matchAccept(
+            [
+                "type"    => "exact",
+                "pattern" => "/foo/bar",
+                "action"  => "FooBar",
+                "accept"  => true
+            ],
+            [
+                "HTTP_ACCEPT" => "text/html;q=0.1"
             ]
-        );
-
-        $resp = $r->match_accept(
-            $route,
-            array(
-                "HTTP_ACCEPT" => "text/html;q=1.0,application/json;q=1.0"
-            )
-        );
-        $this->assertEquals(
-            "application/json",
-            $resp["accept"]
-        );
-    }
-
-    public function testAcceptMatchNone() {
-        $r = new Router();
-
-        $route = array(
-            "type" => "exact",
-            "pattern" => "/foo/bar",
-            "action" => "FooBar",
-            "accept" => [
-                "application/json",
-                "text/html"
-            ]
-        );
-
-        $resp = $r->match_accept(
-            $route,
-            []
-        );
-        $this->assertEquals(
-            "application/json",
-            $resp["accept"]
-        );
-    }
-
-    public function testAcceptMatchPartialWildcard() {
-        $r = new Router();
-
-        $route = array(
-            "type" => "exact",
-            "pattern" => "/foo/bar",
-            "action" => "FooBar",
-            "accept" => [
-                "application/json",
-                "text/html"
-            ]
-        );
-
-        $resp = $r->match_accept(
-            $route,
-            array(
-                "HTTP_ACCEPT" => "text/html;q=1.0,*/json;q=1.0"
-            )
-        );
-        $this->assertEquals(
-            "application/json",
-            $resp["accept"]
-        );
-    }
-
-    public function testAcceptMatchWildcard() {
-        $r = new Router();
-
-        $route = array(
-            "type" => "exact",
-            "pattern" => "/foo/bar",
-            "action" => "FooBar",
-            "accept" => [
-                "application/json"
-            ]
-        );
-
-        $resp = $r->match_accept(
-            $route,
-            array(
-                "HTTP_ACCEPT" => "text/html;q=1.0,*/*;q=1.0"
-            )
-        );
-        $this->assertEquals(
-            "application/json",
-            $resp["accept"]
-        );
-    }
-
-    public function testAcceptMatchCase() {
-        $r = new Router();
-
-        $route = array(
-            "type" => "exact",
-            "pattern" => "/foo/bar",
-            "action" => "FooBar",
-            "accept" => [
-                "application/JSON",
-                "text/html"
-            ]
-        );
-
-        $resp = $r->match_accept(
-            $route,
-            array(
-                "HTTP_ACCEPT" => "text/html;q=1.0,*/Json;q=1.0"
-            )
-        );
-        $this->assertEquals(
-            "application/JSON",
-            $resp["accept"]
         );
     }
 
     public function testCheckMatchString() {
         $r = new Router();
-        $result = $r->check_match("foo", "foo");
+        $result = $r->checkMatch("foo", "foo");
         $this->assertEquals(
-            array(),
+            [],
             $result
         );
-        $result = $r->check_match("foo", "bar");
+        $result = $r->checkMatch("foo", "bar");
         $this->assertEquals(
             false,
             $result
@@ -933,33 +851,33 @@ class RouterTest extends \PHPUnit\Framework\TestCase {
 
     public function testCheckMatchSimpleArray() {
         $r = new Router();
-        $result = $r->check_match(
-            array(
+        $result = $r->checkMatch(
+            [
                 "foo",
                 "bar"
-            ),
+            ],
             "foo"
         );
         $this->assertEquals(
-            array(),
+            [],
             $result
         );
-        $result = $r->check_match(
-            array(
+        $result = $r->checkMatch(
+            [
                 "foo",
                 "bar"
-            ),
+            ],
             "bar"
         );
         $this->assertEquals(
-            array(),
+            [],
             $result
         );
-        $result = $r->check_match(
-            array(
+        $result = $r->checkMatch(
+            [
                 "foo",
                 "bar"
-            ),
+            ],
             "foz"
         );
         $this->assertEquals(
@@ -970,22 +888,22 @@ class RouterTest extends \PHPUnit\Framework\TestCase {
 
     public function testCheckMatchArrayExact() {
         $r = new Router();
-        $result = $r->check_match(
-            array(
+        $result = $r->checkMatch(
+            [
                 "type" => "exact",
                 "pattern" => "foo"
-            ),
+            ],
             "foo"
         );
         $this->assertEquals(
-            array(),
+            [],
             $result
         );
-        $result = $r->check_match(
-            array(
+        $result = $r->checkMatch(
+            [
                 "type" => "exact",
                 "pattern" => "foo"
-            ),
+            ],
             "foz"
         );
         $this->assertEquals(
@@ -996,23 +914,23 @@ class RouterTest extends \PHPUnit\Framework\TestCase {
 
     public function testCheckMatchArrayStartsWith() {
         $r = new Router();
-        $result = $r->check_match(
-            array(
+        $result = $r->checkMatch(
+            [
                 "type" => "starts_with",
                 "pattern" => "/foo"
-            ),
+            ],
             "/foo"
         );
         $this->assertEquals(
-            array(),
+            [],
             $result
         );
 
-        $result = $r->check_match(
-            array(
+        $result = $r->checkMatch(
+            [
                 "type" => "starts_with",
                 "pattern" => "/foo"
-            ),
+            ],
             "/foo/bar"
         );
         $this->assertEquals(
@@ -1020,11 +938,11 @@ class RouterTest extends \PHPUnit\Framework\TestCase {
             $result
         );
 
-        $result = $r->check_match(
-            array(
+        $result = $r->checkMatch(
+            [
                 "type" => "starts_with",
                 "pattern" => "/foo"
-            ),
+            ],
             "/foz/bar"
         );
         $this->assertEquals(
@@ -1035,30 +953,106 @@ class RouterTest extends \PHPUnit\Framework\TestCase {
 
     public function testCheckMatchRegex() {
         $r = new Router();
-        $result = $r->check_match(
-            array(
+        $result = $r->checkMatch(
+            [
                 "type" => "regex",
                 "pattern" => "!^/foo!"
-            ),
+            ],
             "/foo"
         );
         $this->assertEquals(
-            array(),
+            [],
             $result
         );
 
-        $result = $r->check_match(
-            array(
+        $result = $r->checkMatch(
+            [
                 "type" => "regex",
                 "pattern" => "!^/foo/(\d+)/!"
-            ),
+            ],
             "/foo/1/"
         );
         $this->assertEquals(
-            array(
+            [
                 1
-            ),
+            ],
             $result
         );
+    }
+
+    /**
+     * @dataProvider badRoutes
+     */
+    public function testBadRoutes($routes, $expectCode) {
+
+        $this->expectException(\PageMill\Router\Exception\InvalidRoute::class);
+        $this->expectExceptionCode($expectCode);
+
+        $r = new Router($routes);
+        $r->match("/");
+    }
+
+    public function badRoutes() {
+        return [
+            "No type set for route" => [
+                [
+                    [
+                        "pattern" => "/",
+                        "action" => "Foo",
+                    ]
+                ],
+                1
+            ],
+
+            "Routes should include an action or routes, but not both" => [
+                [
+                    [
+                        "type" => "exact",
+                        "pattern" => "/",
+                        "action" => "Foo",
+                        "routes" => [
+                            "type" => "exact",
+                            "pattern" => "/",
+                            "action" => "Foo",
+                        ]
+                    ]
+                ],
+                2
+            ],
+
+            "Routes must include an action or routes" => [
+                [
+                    [
+                        "type" => "exact",
+                        "pattern" => "/",
+                    ]
+                ],
+                3
+            ],
+
+            "Multiple default routes defined" => [
+                [
+                    [
+                        "type" => "default",
+                        "action" => "Foo",
+                    ],
+                    [
+                        "type" => "default",
+                        "action" => "Bar",
+                    ]
+                ],
+                4
+            ],
+
+            "No pattern set for route" => [
+                [
+                    [
+                        "type" => "exact",
+                        "action" => "Foo",
+                    ]
+                ],
+                5
+            ],
+        ];
     }
 }

--- a/tests/RouterTest.php
+++ b/tests/RouterTest.php
@@ -4,54 +4,6 @@ namespace PageMill\Router;
 
 class RouterTest extends \PHPUnit\Framework\TestCase {
 
-    public function testConstructor() {
-        $r = new Router(
-            [
-                [
-                    "type" => "exact",
-                    "pattern" => "/foo",
-                    "action" => "Foo",
-                    "tokens" => []
-                ],
-                [
-                    "type" => "exact",
-                    "pattern" => "/foo/bar",
-                    "action" => "FooBar",
-                    "tokens" => []
-                ],
-            ]
-        );
-
-        $route = $r->match("/foo");
-        $this->assertEquals(
-            [
-                "type" => "exact",
-                "pattern" => "/foo",
-                "action" => "Foo",
-                "tokens" => []
-            ],
-            $route
-        );
-
-        $route = $r->match("/foo/bar");
-        $this->assertEquals(
-            [
-                "type" => "exact",
-                "pattern" => "/foo/bar",
-                "action" => "FooBar",
-                "tokens" => []
-            ],
-            $route
-        );
-
-        $route = $r->match("/foo/bar/baz");
-        $this->assertEquals(
-            [],
-            $route
-        );
-    }
-
-
     public function testAdd() {
         $r = new Router();
         $r->add(
@@ -368,64 +320,8 @@ class RouterTest extends \PHPUnit\Framework\TestCase {
                 "pattern" => "/foo/bar",
                 "action" => "FooBar",
                 "method" => "GET",
-                "tokens" => [
-                    "1"
-                ]
+                "tokens" => []
             ],
-            $resp
-        );
-
-        $resp = $r->matchPath(
-            $route,
-            "/foo/bar/1/2/"
-        );
-        $this->assertEquals(
-            [
-                "type" => "starts_with",
-                "pattern" => "/foo/bar",
-                "action" => "FooBar",
-                "method" => "GET",
-                "tokens" => [
-                    "1",
-                    "2"
-                ]
-            ],
-            $resp
-        );
-
-        $route = [
-            "type" => "starts_with",
-            "pattern" => "/foo/bar",
-            "action" => "FooBar",
-            "method" => "GET",
-            "tokens" => [
-                "id"
-            ]
-        ];
-
-        $resp = $r->matchPath(
-            $route,
-            "/foo/bar/1/"
-        );
-        $this->assertEquals(
-            [
-                "type" => "starts_with",
-                "pattern" => "/foo/bar",
-                "action" => "FooBar",
-                "method" => "GET",
-                "tokens" => [
-                    "id" => "1",
-                ]
-            ],
-            $resp
-        );
-
-        $resp = $r->matchPath(
-            $route,
-            "/foo/bar/1/2/"
-        );
-        $this->assertEquals(
-            [],
             $resp
         );
     }
@@ -844,7 +740,7 @@ class RouterTest extends \PHPUnit\Framework\TestCase {
         );
         $result = $r->checkMatch("foo", "bar");
         $this->assertEquals(
-            false,
+            null,
             $result
         );
     }
@@ -881,12 +777,12 @@ class RouterTest extends \PHPUnit\Framework\TestCase {
             "foz"
         );
         $this->assertEquals(
-            false,
+            null,
             $result
         );
     }
 
-    public function testCheckMatchArrayExact() {
+    public function testCheckMatchPlanArray() {
         $r = new Router();
         $result = $r->checkMatch(
             [
@@ -907,75 +803,7 @@ class RouterTest extends \PHPUnit\Framework\TestCase {
             "foz"
         );
         $this->assertEquals(
-            false,
-            $result
-        );
-    }
-
-    public function testCheckMatchArrayStartsWith() {
-        $r = new Router();
-        $result = $r->checkMatch(
-            [
-                "type" => "starts_with",
-                "pattern" => "/foo"
-            ],
-            "/foo"
-        );
-        $this->assertEquals(
-            [],
-            $result
-        );
-
-        $result = $r->checkMatch(
-            [
-                "type" => "starts_with",
-                "pattern" => "/foo"
-            ],
-            "/foo/bar"
-        );
-        $this->assertEquals(
-            "/bar",
-            $result
-        );
-
-        $result = $r->checkMatch(
-            [
-                "type" => "starts_with",
-                "pattern" => "/foo"
-            ],
-            "/foz/bar"
-        );
-        $this->assertEquals(
-            false,
-            $result
-        );
-    }
-
-    public function testCheckMatchRegex() {
-        $r = new Router();
-        $result = $r->checkMatch(
-            [
-                "type" => "regex",
-                "pattern" => "!^/foo!"
-            ],
-            "/foo"
-        );
-        $this->assertEquals(
-            [],
-            $result
-        );
-
-        $result = $r->checkMatch(
-            [
-                "type" => "regex",
-                "pattern" => "!^/foo/(\d+)/!"
-            ],
-            "/foo/1/"
-        );
-        $this->assertEquals(
-            [
-                1
-            ],
+            null,
             $result
         );
     }


### PR DESCRIPTION
* Updated to use PHP 7.3 features such as new type hints
* Updated methods to use camelCase
* Added additional testing, especially of exceptions
* Remove redundant add_map() method as code using methods should be using add() and createRoute() instead.
* Remove unused exception class
* Changed the return type of functions that were returning false or an array to return an empty array or filled array to allow for better return type enforcement.

